### PR TITLE
Update dark mode color scheme to use semantic color tokens

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,7 +30,7 @@ function App() {
   return (
     <SEOWrapper>
       <div className={`min-h-screen ${darkMode ? "dark" : ""}`}>
-        <div className="bg-white dark:bg-gray-900 text-gray-900 dark:text-white transition-colors duration-300">
+        <div className="bg-white dark:bg-neutral-charcoal text-gray-900 dark:text-primary-200 transition-colors duration-300">
           <Navbar darkMode={darkMode} setDarkMode={setDarkMode} />
           <main>
             <Hero />

--- a/src/components/FleetCarousel.jsx
+++ b/src/components/FleetCarousel.jsx
@@ -126,15 +126,15 @@ const FleetCarousel = () => {
   return (
     <section
       id="fleet"
-      className="section-padding bg-neutral-cream dark:bg-dark-bg"
+      className="section-padding bg-neutral-cream dark:bg-neutral-charcoal"
     >
       <div className="container px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-12 sm:mb-16 space-y-4 sm:space-y-6">
-          <h2 className="text-3xl sm:text-4xl lg:text-5xl font-light text-primary-800 dark:text-dark-primary-text">
+          <h2 className="text-3xl sm:text-4xl lg:text-5xl font-light text-primary-800 dark:text-primary-200">
             Affordable
             <span className="font-semibold"> Collection</span>
           </h2>
-          <p className="text-lg sm:text-xl text-neutral-medium-grey dark:text-dark-muted-text max-w-3xl mx-auto leading-relaxed">
+          <p className="text-lg sm:text-xl text-neutral-medium-grey dark:text-neutral-warm-grey max-w-3xl mx-auto leading-relaxed">
             Discover our carefully selected vehicles, each maintained to high
             standards for your comfort and safety at competitive rates.
           </p>
@@ -154,7 +154,7 @@ const FleetCarousel = () => {
             >
               {vehicles.map((vehicle) => (
                 <div key={vehicle.id} className="w-full flex-shrink-0">
-                  <div className="bg-neutral-warm-white dark:bg-dark-card-border rounded-xl sm:rounded-2xl shadow-soft border border-neutral-muted-grey/30 dark:border-dark-card-border-alt p-6 sm:p-8 hover:shadow-warm transition-all duration-300">
+                  <div className="bg-neutral-warm-white dark:bg-neutral-deep-brown rounded-xl sm:rounded-2xl shadow-soft border border-neutral-muted-grey/30 dark:border-neutral-medium-grey/30 p-6 sm:p-8 hover:shadow-warm transition-all duration-300">
                     <div className="relative mb-6 sm:mb-8">
                       <img
                         src={vehicle.image}
@@ -163,7 +163,7 @@ const FleetCarousel = () => {
                         loading="lazy"
                       />
                       <div className="absolute top-4 sm:top-6 right-4 sm:right-6">
-                        <span className="px-3 sm:px-4 py-1.5 sm:py-2 bg-neutral-warm-white/95 dark:bg-dark-card-border/95 backdrop-blur-sm rounded-lg sm:rounded-xl text-xs sm:text-sm font-medium text-primary-700 dark:text-dark-accent border border-neutral-muted-grey/30 dark:border-dark-card-border-alt">
+                        <span className="px-3 sm:px-4 py-1.5 sm:py-2 bg-neutral-warm-white/95 dark:bg-neutral-deep-brown/95 backdrop-blur-sm rounded-lg sm:rounded-xl text-xs sm:text-sm font-medium text-primary-700 dark:text-primary-400 border border-neutral-muted-grey/30 dark:border-neutral-medium-grey/30">
                           Climate Control
                         </span>
                       </div>
@@ -172,34 +172,34 @@ const FleetCarousel = () => {
                     <div className="space-y-4 sm:space-y-6">
                       <div className="flex flex-col sm:flex-row sm:justify-between sm:items-start gap-3 sm:gap-0">
                         <div className="space-y-1 sm:space-y-2">
-                          <h3 className="text-xl sm:text-2xl lg:text-3xl font-semibold text-primary-800 dark:text-dark-primary-text">
+                          <h3 className="text-xl sm:text-2xl lg:text-3xl font-semibold text-primary-800 dark:text-primary-200">
                             {vehicle.name}
                           </h3>
-                          <p className="text-base sm:text-lg text-neutral-medium-grey dark:text-dark-muted-text">
+                          <p className="text-base sm:text-lg text-neutral-medium-grey dark:text-neutral-warm-grey">
                             {vehicle.type}
                           </p>
                         </div>
                         <div className="text-left sm:text-right">
-                          <div className="text-xl sm:text-2xl font-semibold text-primary-700 dark:text-dark-accent">
+                          <div className="text-xl sm:text-2xl font-semibold text-primary-700 dark:text-primary-400">
                             {vehicle.price}
                           </div>
                         </div>
                       </div>
 
                       <div className="flex flex-wrap items-center gap-4 sm:gap-6">
-                        <div className="flex items-center gap-2 text-neutral-medium-grey dark:text-dark-muted-text">
+                        <div className="flex items-center gap-2 text-neutral-medium-grey dark:text-neutral-warm-grey">
                           <FiUsers size={16} />
                           <span className="text-sm">
                             {vehicle.seats} passengers
                           </span>
                         </div>
-                        <div className="flex items-center gap-2 text-neutral-medium-grey dark:text-dark-muted-text">
+                        <div className="flex items-center gap-2 text-neutral-medium-grey dark:text-neutral-warm-grey">
                           <FiSettings size={16} />
                           <span className="text-sm">
                             {vehicle.transmission}
                           </span>
                         </div>
-                        <div className="flex items-center gap-2 text-neutral-medium-grey dark:text-dark-muted-text">
+                        <div className="flex items-center gap-2 text-neutral-medium-grey dark:text-neutral-warm-grey">
                           <FiWind size={16} />
                           <span className="text-sm">Climate Control</span>
                         </div>
@@ -209,7 +209,7 @@ const FleetCarousel = () => {
                       <div className="space-y-3">
                         <button
                           onClick={() => toggleFeatures(vehicle.id)}
-                          className="flex items-center justify-between w-full sm:hidden font-semibold text-primary-800 dark:text-dark-primary-text"
+                          className="flex items-center justify-between w-full sm:hidden font-semibold text-primary-800 dark:text-primary-200"
                         >
                           <span>Key Features</span>
                           {expandedFeatures[vehicle.id] ? (
@@ -221,14 +221,14 @@ const FleetCarousel = () => {
 
                         {/* Desktop Features - Always Visible */}
                         <div className="hidden sm:block">
-                          <h4 className="font-semibold text-primary-800 dark:text-dark-primary-text mb-3">
+                          <h4 className="font-semibold text-primary-800 dark:text-primary-200 mb-3">
                             Key Features
                           </h4>
                           <div className="grid grid-cols-1 sm:grid-cols-3 gap-2 sm:gap-3">
                             {vehicle.features.map((feature, index) => (
                               <div
                                 key={index}
-                                className="px-3 sm:px-4 py-2 bg-neutral-beige dark:bg-dark-card-border-alt rounded-lg sm:rounded-xl text-sm text-neutral-charcoal dark:text-dark-primary-text border border-neutral-muted-grey/30 dark:border-dark-card-border"
+                                className="px-3 sm:px-4 py-2 bg-neutral-beige dark:bg-neutral-medium-grey/30 rounded-lg sm:rounded-xl text-sm text-neutral-charcoal dark:text-primary-200 border border-neutral-muted-grey/30 dark:border-neutral-medium-grey/30"
                               >
                                 {feature}
                               </div>
@@ -270,23 +270,23 @@ const FleetCarousel = () => {
           {/* Navigation arrows - Positioned outside the carousel */}
           <button
             onClick={prevSlide}
-            className="absolute -left-4 sm:-left-16 top-1/2 transform -translate-y-1/2 bg-black/30 sm:bg-neutral-warm-white/95 dark:bg-dark-card-border/95 backdrop-blur-sm p-3 sm:p-4 rounded-xl sm:rounded-2xl shadow-gentle hover:shadow-soft transition-all duration-300 border border-transparent sm:border-neutral-muted-grey/30 dark:border-dark-card-border-alt z-10"
+            className="absolute -left-4 sm:-left-16 top-1/2 transform -translate-y-1/2 bg-black/30 sm:bg-neutral-warm-white/95 dark:bg-neutral-deep-brown/95 backdrop-blur-sm p-3 sm:p-4 rounded-xl sm:rounded-2xl shadow-gentle hover:shadow-soft transition-all duration-300 border border-transparent sm:border-neutral-muted-grey/30 dark:border-neutral-medium-grey/30 z-10"
             aria-label="Previous vehicle"
           >
             <FiChevronLeft
               size={20}
-              className="text-white sm:text-primary-700 dark:text-dark-accent"
+              className="text-white sm:text-primary-700 dark:text-primary-400"
             />
           </button>
 
           <button
             onClick={nextSlide}
-            className="absolute -right-4 sm:-right-16 top-1/2 transform -translate-y-1/2 bg-black/30 sm:bg-neutral-warm-white/95 dark:bg-dark-card-border/95 backdrop-blur-sm p-3 sm:p-4 rounded-xl sm:rounded-2xl shadow-gentle hover:shadow-soft transition-all duration-300 border border-transparent sm:border-neutral-muted-grey/30 dark:border-dark-card-border-alt z-10"
+            className="absolute -right-4 sm:-right-16 top-1/2 transform -translate-y-1/2 bg-black/30 sm:bg-neutral-warm-white/95 dark:bg-neutral-deep-brown/95 backdrop-blur-sm p-3 sm:p-4 rounded-xl sm:rounded-2xl shadow-gentle hover:shadow-soft transition-all duration-300 border border-transparent sm:border-neutral-muted-grey/30 dark:border-neutral-medium-grey/30 z-10"
             aria-label="Next vehicle"
           >
             <FiChevronRight
               size={20}
-              className="text-white sm:text-primary-700 dark:text-dark-accent"
+              className="text-white sm:text-primary-700 dark:text-primary-400"
             />
           </button>
 
@@ -298,8 +298,8 @@ const FleetCarousel = () => {
                 onClick={() => goToSlide(index)}
                 className={`h-2 rounded-full transition-all duration-300 ${
                   index === currentIndex
-                    ? "w-6 sm:w-8 bg-primary-600 dark:bg-dark-accent"
-                    : "w-2 bg-neutral-warm-grey dark:bg-dark-muted-text hover:bg-primary-400 dark:hover:bg-dark-hover-highlight"
+                    ? "w-6 sm:w-8 bg-primary-600 dark:bg-primary-400"
+                    : "w-2 bg-neutral-warm-grey dark:bg-neutral-warm-grey hover:bg-primary-400 dark:hover:bg-primary-300"
                 }`}
                 aria-label={`Go to vehicle ${index + 1}`}
               />

--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -12,20 +12,20 @@ const Hero = () => {
   return (
     <section
       id="home"
-      className="min-h-screen flex items-center gradient-warm dark:bg-gradient-to-br dark:from-dark-bg dark:to-dark-card-border"
+      className="min-h-screen flex items-center gradient-warm dark:bg-gradient-to-br dark:from-neutral-charcoal dark:to-neutral-deep-brown"
     >
       <div className="container px-4 sm:px-6 lg:px-8">
         <div className="max-w-4xl mx-auto text-center space-y-6 sm:space-y-8 pt-8 sm:pt-16">
           {/* Content */}
           <div className="space-y-6">
-            <h1 className="text-4xl sm:text-5xl lg:text-6xl xl:text-7xl font-light text-primary-800 dark:text-dark-primary-text leading-tight">
+            <h1 className="text-4xl sm:text-5xl lg:text-6xl xl:text-7xl font-light text-primary-800 dark:text-primary-200 leading-tight">
               Affordable Car
-              <span className="block font-semibold text-gradient dark:text-dark-accent">
+              <span className="block font-semibold text-gradient dark:text-primary-400">
                 Rental Experience
               </span>
             </h1>
 
-            <p className="text-lg sm:text-xl lg:text-2xl text-neutral-medium-grey dark:text-dark-muted-text leading-relaxed max-w-3xl mx-auto">
+            <p className="text-lg sm:text-xl lg:text-2xl text-neutral-medium-grey dark:text-neutral-warm-grey leading-relaxed max-w-3xl mx-auto">
               Discover quality vehicles and personalized service at competitive
               rates. Your journey begins with our carefully selected fleet.
             </p>
@@ -54,26 +54,26 @@ const Hero = () => {
           {/* Trust indicators */}
           <div className="pt-12 grid grid-cols-3 gap-4 sm:gap-8 max-w-2xl mx-auto">
             <div className="text-center">
-              <div className="text-2xl sm:text-3xl font-semibold text-primary-700 dark:text-dark-accent mb-2">
+              <div className="text-2xl sm:text-3xl font-semibold text-primary-700 dark:text-primary-400 mb-2">
                 500+
               </div>
-              <div className="text-xs sm:text-sm text-neutral-medium-grey dark:text-dark-muted-text uppercase tracking-wide">
+              <div className="text-xs sm:text-sm text-neutral-medium-grey dark:text-neutral-warm-grey uppercase tracking-wide">
                 Satisfied Clients
               </div>
             </div>
             <div className="text-center">
-              <div className="text-2xl sm:text-3xl font-semibold text-primary-700 dark:text-dark-accent mb-2">
+              <div className="text-2xl sm:text-3xl font-semibold text-primary-700 dark:text-primary-400 mb-2">
                 4.9
               </div>
-              <div className="text-xs sm:text-sm text-neutral-medium-grey dark:text-dark-muted-text uppercase tracking-wide">
+              <div className="text-xs sm:text-sm text-neutral-medium-grey dark:text-neutral-warm-grey uppercase tracking-wide">
                 Average Rating
               </div>
             </div>
             <div className="text-center">
-              <div className="text-2xl sm:text-3xl font-semibold text-primary-700 dark:text-dark-accent mb-2">
+              <div className="text-2xl sm:text-3xl font-semibold text-primary-700 dark:text-primary-400 mb-2">
                 5+
               </div>
-              <div className="text-xs sm:text-sm text-neutral-medium-grey dark:text-dark-muted-text uppercase tracking-wide">
+              <div className="text-xs sm:text-sm text-neutral-medium-grey dark:text-neutral-warm-grey uppercase tracking-wide">
                 Years Experience
               </div>
             </div>

--- a/src/components/HowItWorks.jsx
+++ b/src/components/HowItWorks.jsx
@@ -9,8 +9,8 @@ const HowItWorks = () => {
       title: "Explore Collection",
       description:
         "Browse our quality fleet and discover the perfect vehicle for your journey. Each car is well-maintained and equipped with modern amenities.",
-      color: "bg-primary-100 dark:bg-dark-card-border",
-      textColor: "text-primary-700 dark:text-dark-accent",
+      color: "bg-primary-100 dark:bg-primary-900/20",
+      textColor: "text-primary-700 dark:text-primary-400",
     },
     {
       id: 2,
@@ -18,8 +18,8 @@ const HowItWorks = () => {
       title: "Connect With Us",
       description:
         "Contact our friendly team via phone or WhatsApp. Our team will assist you in selecting the ideal vehicle and handling your booking.",
-      color: "bg-primary-100 dark:bg-dark-card-border",
-      textColor: "text-primary-700 dark:text-dark-accent",
+      color: "bg-primary-100 dark:bg-primary-900/20",
+      textColor: "text-primary-700 dark:text-primary-400",
     },
     {
       id: 3,
@@ -27,23 +27,23 @@ const HowItWorks = () => {
       title: "Begin Your Journey",
       description:
         "Complete your booking, receive confirmation details, and enjoy a seamless, affordable driving experience with our reliable support.",
-      color: "bg-primary-100 dark:bg-dark-card-border",
-      textColor: "text-primary-700 dark:text-dark-accent",
+      color: "bg-primary-100 dark:bg-primary-900/20",
+      textColor: "text-primary-700 dark:text-primary-400",
     },
   ];
 
   return (
     <section
       id="how-it-works"
-      className="section-padding bg-neutral-warm-white dark:bg-dark-bg"
+      className="section-padding bg-neutral-warm-white dark:bg-neutral-charcoal"
     >
       <div className="container px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-12 sm:mb-20 space-y-4 sm:space-y-6">
-          <h2 className="text-3xl sm:text-4xl lg:text-5xl font-light text-primary-800 dark:text-dark-primary-text">
+          <h2 className="text-3xl sm:text-4xl lg:text-5xl font-light text-primary-800 dark:text-primary-200">
             Simple
             <span className="font-semibold"> Process</span>
           </h2>
-          <p className="text-lg sm:text-xl text-neutral-medium-grey dark:text-dark-muted-text max-w-3xl mx-auto leading-relaxed">
+          <p className="text-lg sm:text-xl text-neutral-medium-grey dark:text-neutral-warm-grey max-w-3xl mx-auto leading-relaxed">
             Experience our streamlined approach to affordable car rental. Three
             simple steps to your perfect vehicle.
           </p>
@@ -54,8 +54,8 @@ const HowItWorks = () => {
             <div key={step.id} className="relative">
               {/* Connection line - hidden on mobile, visible on desktop */}
               {index < steps.length - 1 && (
-                <div className="hidden md:block absolute top-12 left-full w-full h-px bg-gradient-to-r from-neutral-warm-grey dark:from-dark-muted-text via-neutral-muted-grey dark:via-dark-card-border-alt to-transparent z-0">
-                  <div className="absolute top-1/2 right-0 transform translate-x-2 -translate-y-1/2 w-2 h-2 bg-neutral-warm-grey dark:bg-dark-muted-text rounded-full"></div>
+                <div className="hidden md:block absolute top-12 left-full w-full h-px bg-gradient-to-r from-neutral-warm-grey dark:from-neutral-warm-grey via-neutral-muted-grey dark:via-neutral-medium-grey/30 to-transparent z-0">
+                  <div className="absolute top-1/2 right-0 transform translate-x-2 -translate-y-1/2 w-2 h-2 bg-neutral-warm-grey dark:bg-neutral-warm-grey rounded-full"></div>
                 </div>
               )}
 
@@ -69,10 +69,10 @@ const HowItWorks = () => {
 
                 {/* Content */}
                 <div className="space-y-3 sm:space-y-4">
-                  <h3 className="text-xl sm:text-2xl font-semibold text-primary-800 dark:text-dark-primary-text">
+                  <h3 className="text-xl sm:text-2xl font-semibold text-primary-800 dark:text-primary-200">
                     {step.title}
                   </h3>
-                  <p className="text-neutral-medium-grey dark:text-dark-muted-text leading-relaxed text-sm sm:text-base">
+                  <p className="text-neutral-medium-grey dark:text-neutral-warm-grey leading-relaxed text-sm sm:text-base">
                     {step.description}
                   </p>
                 </div>
@@ -82,12 +82,12 @@ const HowItWorks = () => {
         </div>
 
         {/* Support section */}
-        <div className="mt-12 sm:mt-20 bg-neutral-warm-white dark:bg-dark-card-border rounded-xl sm:rounded-2xl shadow-soft border border-neutral-muted-grey/30 dark:border-dark-card-border-alt p-6 sm:p-8 hover:shadow-warm transition-all duration-300 max-w-4xl mx-auto text-center">
+        <div className="mt-12 sm:mt-20 bg-neutral-warm-white dark:bg-neutral-deep-brown rounded-xl sm:rounded-2xl shadow-soft border border-neutral-muted-grey/30 dark:border-neutral-medium-grey/30 p-6 sm:p-8 hover:shadow-warm transition-all duration-300 max-w-4xl mx-auto text-center">
           <div className="space-y-4 sm:space-y-6">
-            <h3 className="text-xl sm:text-2xl lg:text-3xl font-semibold text-primary-800 dark:text-dark-primary-text">
+            <h3 className="text-xl sm:text-2xl lg:text-3xl font-semibold text-primary-800 dark:text-primary-200">
               Need Assistance?
             </h3>
-            <p className="text-base sm:text-lg text-neutral-medium-grey dark:text-dark-muted-text leading-relaxed max-w-2xl mx-auto">
+            <p className="text-base sm:text-lg text-neutral-medium-grey dark:text-neutral-warm-grey leading-relaxed max-w-2xl mx-auto">
               Our dedicated customer service team is available throughout your
               entire journey. From vehicle selection to return, we ensure your
               experience exceeds expectations.
@@ -96,7 +96,7 @@ const HowItWorks = () => {
             <div className="flex flex-col sm:flex-row gap-3 sm:gap-4 justify-center pt-2 sm:pt-4">
               <a
                 href="tel:+1234567890"
-                className="bg-primary-600 hover:bg-primary-700 dark:bg-dark-accent dark:hover:bg-dark-hover-highlight text-neutral-warm-white font-medium px-6 sm:px-8 py-3 sm:py-4 rounded-lg sm:rounded-xl transition-all duration-300 inline-flex items-center justify-center gap-2 sm:gap-3"
+                className="bg-primary-600 hover:bg-primary-700 dark:bg-primary-400 dark:hover:bg-primary-300 text-neutral-warm-white dark:text-neutral-charcoal font-medium px-6 sm:px-8 py-3 sm:py-4 rounded-lg sm:rounded-xl transition-all duration-300 inline-flex items-center justify-center gap-2 sm:gap-3"
               >
                 <FiPhone size={18} />
                 Contact Us
@@ -105,7 +105,7 @@ const HowItWorks = () => {
                 href="https://wa.me/1234567890"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="bg-neutral-warm-white hover:bg-neutral-beige dark:bg-dark-card-border-alt dark:hover:bg-dark-hover-alt text-primary-700 dark:text-dark-primary-text font-medium px-6 sm:px-8 py-3 sm:py-4 rounded-lg sm:rounded-xl transition-all duration-300 inline-flex items-center justify-center gap-2 sm:gap-3 border border-neutral-warm-grey dark:border-dark-card-border"
+                className="bg-neutral-warm-white hover:bg-neutral-beige dark:bg-neutral-medium-grey/30 dark:hover:bg-neutral-medium-grey/50 text-primary-700 dark:text-primary-200 font-medium px-6 sm:px-8 py-3 sm:py-4 rounded-lg sm:rounded-xl transition-all duration-300 inline-flex items-center justify-center gap-2 sm:gap-3 border border-neutral-warm-grey dark:border-neutral-medium-grey/30"
               >
                 WhatsApp Support
                 <FiArrowRight size={18} />

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -33,7 +33,7 @@ const Navbar = ({ darkMode, setDarkMode }) => {
     <nav
       className={`fixed top-0 left-0 right-0 z-50 transition-all duration-300 ${
         scrolled
-          ? "bg-neutral-warm-white/95 dark:bg-dark-bg/95 backdrop-blur-md shadow-gentle border-b border-neutral-muted-grey/20 dark:border-dark-card-border"
+          ? "bg-neutral-warm-white/95 dark:bg-neutral-charcoal/95 backdrop-blur-md shadow-gentle border-b border-neutral-muted-grey/20 dark:border-neutral-medium-grey/30"
           : "bg-transparent"
       }`}
     >
@@ -43,7 +43,7 @@ const Navbar = ({ darkMode, setDarkMode }) => {
           <div className="flex items-center flex-shrink-0">
             <button
               onClick={() => handleLinkClick("#home")}
-              className="text-xl sm:text-2xl lg:text-3xl font-semibold text-primary-800 dark:text-dark-primary-text hover:text-primary-700 dark:hover:text-dark-accent transition-colors"
+              className="text-xl sm:text-2xl lg:text-3xl font-semibold text-primary-800 dark:text-primary-200 hover:text-primary-700 dark:hover:text-primary-400 transition-colors"
             >
               EasyDrive
             </button>
@@ -55,7 +55,7 @@ const Navbar = ({ darkMode, setDarkMode }) => {
               <button
                 key={item.name}
                 onClick={() => handleLinkClick(item.href)}
-                className="text-neutral-charcoal dark:text-dark-primary-text hover:text-primary-700 dark:hover:text-dark-accent font-medium transition-colors relative group py-2"
+                className="text-neutral-charcoal dark:text-primary-200 hover:text-primary-700 dark:hover:text-primary-400 font-medium transition-colors relative group py-2"
               >
                 {item.name}
                 <span className="absolute bottom-0 left-0 w-0 h-0.5 bg-primary-600 dark:bg-primary-400 transition-all duration-300 group-hover:w-full"></span>
@@ -65,7 +65,7 @@ const Navbar = ({ darkMode, setDarkMode }) => {
             {/* Dark Mode Toggle */}
             <button
               onClick={() => setDarkMode(!darkMode)}
-              className="p-3 rounded-xl bg-neutral-soft-grey dark:bg-dark-card-border hover:bg-neutral-muted-grey dark:hover:bg-dark-card-border-alt text-neutral-charcoal dark:text-dark-primary-text transition-all duration-300"
+              className="p-3 rounded-xl bg-neutral-soft-grey dark:bg-neutral-deep-brown hover:bg-neutral-muted-grey dark:hover:bg-neutral-medium-grey/30 text-neutral-charcoal dark:text-primary-200 transition-all duration-300"
               aria-label="Toggle dark mode"
             >
               {darkMode ? <FiSun size={18} /> : <FiMoon size={18} />}
@@ -76,7 +76,7 @@ const Navbar = ({ darkMode, setDarkMode }) => {
           <div className="lg:hidden flex items-center space-x-2 sm:space-x-3">
             <button
               onClick={() => setDarkMode(!darkMode)}
-              className="p-2 sm:p-2.5 rounded-lg bg-neutral-soft-grey dark:bg-dark-card-border hover:bg-neutral-muted-grey dark:hover:bg-dark-card-border-alt text-neutral-charcoal dark:text-dark-primary-text transition-colors"
+              className="p-2 sm:p-2.5 rounded-lg bg-neutral-soft-grey dark:bg-neutral-deep-brown hover:bg-neutral-muted-grey dark:hover:bg-neutral-medium-grey/30 text-neutral-charcoal dark:text-primary-200 transition-colors"
               aria-label="Toggle dark mode"
             >
               {darkMode ? <FiSun size={16} /> : <FiMoon size={16} />}
@@ -84,7 +84,7 @@ const Navbar = ({ darkMode, setDarkMode }) => {
 
             <button
               onClick={() => setIsOpen(!isOpen)}
-              className="p-2.5 sm:p-3 rounded-lg bg-neutral-soft-grey dark:bg-dark-card-border hover:bg-neutral-muted-grey dark:hover:bg-dark-card-border-alt text-neutral-charcoal dark:text-dark-primary-text transition-colors"
+              className="p-2.5 sm:p-3 rounded-lg bg-neutral-soft-grey dark:bg-neutral-deep-brown hover:bg-neutral-muted-grey dark:hover:bg-neutral-medium-grey/30 text-neutral-charcoal dark:text-primary-200 transition-colors"
               aria-label="Toggle menu"
             >
               {isOpen ? <FiX size={18} /> : <FiMenu size={18} />}
@@ -98,12 +98,12 @@ const Navbar = ({ darkMode, setDarkMode }) => {
             isOpen ? "max-h-96 opacity-100" : "max-h-0 opacity-0"
           }`}
         >
-          <div className="mt-2 mx-4 space-y-1 bg-dark-bg dark:bg-dark-bg rounded-2xl shadow-soft border border-dark-card-border dark:border-dark-card-border">
+          <div className="mt-2 mx-4 space-y-1 bg-neutral-charcoal dark:bg-neutral-charcoal rounded-2xl shadow-soft border border-neutral-medium-grey/30 dark:border-neutral-medium-grey/30">
             {menuItems.map((item) => (
               <button
                 key={item.name}
                 onClick={() => handleLinkClick(item.href)}
-                className="block w-full text-left px-4 sm:px-6 py-3 sm:py-4 text-dark-primary-text dark:text-dark-primary-text hover:bg-dark-card-border-alt dark:hover:bg-dark-card-border-alt hover:text-dark-accent dark:hover:text-dark-accent font-medium transition-colors first:rounded-t-2xl last:rounded-b-2xl"
+                className="block w-full text-left px-4 sm:px-6 py-3 sm:py-4 text-primary-200 dark:text-primary-200 hover:bg-neutral-medium-grey/30 dark:hover:bg-neutral-medium-grey/30 hover:text-primary-400 dark:hover:text-primary-400 font-medium transition-colors first:rounded-t-2xl last:rounded-b-2xl"
               >
                 {item.name}
               </button>

--- a/src/components/Testimonials.jsx
+++ b/src/components/Testimonials.jsx
@@ -89,15 +89,15 @@ const Testimonials = () => {
   return (
     <section
       id="testimonials"
-      className="section-padding bg-neutral-warm-white dark:bg-dark-bg"
+      className="section-padding bg-neutral-warm-white dark:bg-neutral-charcoal"
     >
       <div className="container px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-12 sm:mb-20 space-y-4 sm:space-y-6">
-          <h2 className="text-3xl sm:text-4xl lg:text-5xl font-light text-primary-800 dark:text-dark-primary-text">
+          <h2 className="text-3xl sm:text-4xl lg:text-5xl font-light text-primary-800 dark:text-primary-200">
             Client
             <span className="font-semibold"> Reviews</span>
           </h2>
-          <p className="text-lg sm:text-xl text-neutral-medium-grey dark:text-dark-muted-text max-w-3xl mx-auto leading-relaxed">
+          <p className="text-lg sm:text-xl text-neutral-medium-grey dark:text-neutral-warm-grey max-w-3xl mx-auto leading-relaxed">
             Discover why customers choose EasyDrive for their car rental needs.
             Quality service, reflected in every review.
           </p>
@@ -109,20 +109,20 @@ const Testimonials = () => {
             {testimonials.slice(0, 3).map((testimonial) => (
               <div
                 key={testimonial.id}
-                className="card-premium dark:bg-dark-card-border dark:border-dark-card-border-alt space-y-4 sm:space-y-6"
+                className="card-premium dark:bg-neutral-deep-brown dark:border-neutral-medium-grey/30 space-y-4 sm:space-y-6"
               >
                 <div className="flex items-center space-x-3 sm:space-x-4">
-                  <div className="w-12 sm:w-14 h-12 sm:h-14 bg-primary-100 dark:bg-dark-card-border-alt rounded-xl sm:rounded-2xl flex items-center justify-center text-primary-700 dark:text-dark-accent font-semibold text-base sm:text-lg">
+                  <div className="w-12 sm:w-14 h-12 sm:h-14 bg-primary-100 dark:bg-primary-900/20 rounded-xl sm:rounded-2xl flex items-center justify-center text-primary-700 dark:text-primary-400 font-semibold text-base sm:text-lg">
                     {testimonial.initials}
                   </div>
                   <div className="flex-1">
-                    <h4 className="font-semibold text-base sm:text-lg text-primary-800 dark:text-dark-primary-text">
+                    <h4 className="font-semibold text-base sm:text-lg text-primary-800 dark:text-primary-200">
                       {testimonial.name}
                     </h4>
-                    <p className="text-xs sm:text-sm text-neutral-medium-grey dark:text-dark-muted-text">
+                    <p className="text-xs sm:text-sm text-neutral-medium-grey dark:text-neutral-warm-grey">
                       {testimonial.position}
                     </p>
-                    <p className="text-xs text-neutral-medium-grey dark:text-dark-muted-text">
+                    <p className="text-xs text-neutral-medium-grey dark:text-neutral-warm-grey">
                       {testimonial.company}
                     </p>
                   </div>
@@ -132,7 +132,7 @@ const Testimonials = () => {
                   {renderStars(testimonial.rating)}
                 </div>
 
-                <blockquote className="text-neutral-charcoal dark:text-neutral-beige leading-relaxed text-sm sm:text-base">
+                <blockquote className="text-neutral-charcoal dark:text-neutral-warm-grey leading-relaxed text-sm sm:text-base">
                   "{testimonial.review}"
                 </blockquote>
               </div>


### PR DESCRIPTION
This pull request updates the dark mode color scheme across multiple components to use more semantic color tokens.

Changes include:
- Replace `dark-bg` with `neutral-charcoal` for background colors
- Replace `dark-primary-text` with `primary-200` for primary text
- Replace `dark-muted-text` with `neutral-warm-grey` for secondary text
- Replace `dark-accent` with `primary-400` for accent colors
- Replace `dark-card-border` with `neutral-deep-brown` for card backgrounds
- Replace `dark-card-border-alt` with `neutral-medium-grey/30` for borders and hover states

Components updated:
- App.jsx - Main app background and text colors
- FleetCarousel.jsx - Vehicle cards, text, and navigation elements
- Navbar.jsx - Navigation bar, menu items, and mobile menu
- Testimonials.jsx - Testimonial cards and text elements

The changes maintain visual consistency while using a more organized color token system.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 2`

🔗 [Edit in Builder.io](https://builder.io/app/projects/11d8679266c04682ad40764514b2fb68/aura-nest)

👀 [Preview Link](https://11d8679266c04682ad40764514b2fb68-aura-nest.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>11d8679266c04682ad40764514b2fb68</projectId>-->
<!--<branchName>aura-nest</branchName>-->